### PR TITLE
feat: add .gitignore for Xcode and project dependencies

### DIFF
--- a/SwiftProject/SwiftProject/.gitignore
+++ b/SwiftProject/SwiftProject/.gitignore
@@ -1,0 +1,126 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+*.xcuserstate
+project.xcworkspace/xcuserdata/
+*.xcscmblueprint
+*.xccheckout
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+Packages/
+Package.pins
+Package.resolved
+.build/
+.swiftpm/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+Carthage/Checkouts
+Carthage/Build/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+# OS X temporary files
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# App specific settings
+*.generated.swift
+
+# Sensitive information
+GoogleService-Info.plist
+ApiKeys.plist
+Secrets.plist
+
+# Environment variables
+.env
+.env.local
+.env.development
+.env.test
+.env.production
+
+# R.swift generated files
+*.generated.swift
+
+# SwiftGen generated files
+Generated/
+
+# Ruby environment normalization
+.rbenv-version
+.ruby-version
+.ruby-gemset
+
+# Config files that might be different for each dev
+IDEWorkspaceChecks.plist
+
+# AppCode
+.idea/
+
+# Snapshots
+__Snapshots__/


### PR DESCRIPTION
### Pull Request Description

This pull request introduces a new `.gitignore` file specifically tailored for Xcode projects. The changes aim to enhance the cleanliness of the repository by excluding user-specific files, build artifacts, and various dependency directories that are not necessary for version control.

#### Key Changes:
- Added a comprehensive `.gitignore` file to prevent tracking of:
  - User-specific files
  - Build artifacts
  - Dependency directories

By implementing this `.gitignore`, we aim to improve collaboration among team members and reduce clutter in the repository, ensuring that only relevant files are tracked. This change is essential for maintaining a clean and efficient project structure.

Please review the changes and provide any feedback. Thank you!