### PR TITLE
feat: update .gitignore for Sentry.io integration

### DIFF
--- a/SwiftProject/.gitignore
+++ b/SwiftProject/.gitignore
@@ -204,3 +204,18 @@ fastlane/README.md
 vendor/bundle/
 tmp/
 temp/
+
+### Sentry.io Integration (iOS) ###
+
+# Sentry auth tokens and configs
+.sentryclirc
+sentry.properties
+**/ios/sentry.properties
+
+# Sentry debug symbols
+*.dSYM.zip
+*.dSYM/
+sentry-symbols/
+
+# Sentry build artifacts
+sentry-cli-*


### PR DESCRIPTION
Add entries to .gitignore to exclude Sentry.io configuration files, 
debug symbols, and build artifacts. This prevents sensitive data and 
unnecessary files from being tracked in the repository, ensuring a 
cleaner project structure and improved security.